### PR TITLE
feat: Non-wheel backends installed in venv

### DIFF
--- a/src/mlia/backend/install.py
+++ b/src/mlia/backend/install.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright 2022-2024, Arm Limited and/or its affiliates.
+# SPDX-FileCopyrightText: Copyright 2022-2025, Arm Limited and/or its affiliates.
 # SPDX-License-Identifier: Apache-2.0
 """Module for installation process."""
 from __future__ import annotations
@@ -161,6 +161,9 @@ class BackendInstallation(Installation):
     def _install_from(self, backend_info: BackendInfo) -> None:
         """Install backend from the directory."""
         backend_repo = get_backend_repository()
+        logger.debug(
+            "Installing %s in %s", backend_info.backend_path, backend_repo.repository
+        )
 
         if backend_info.copy_source:
             backend_repo.copy_backend(

--- a/src/mlia/backend/repo.py
+++ b/src/mlia/backend/repo.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright 2023, Arm Limited and/or its affiliates.
+# SPDX-FileCopyrightText: Copyright 2023, 2025, Arm Limited and/or its affiliates.
 # SPDX-License-Identifier: Apache-2.0
 """Module for backend repository.
 
@@ -18,6 +18,7 @@ from configuration file along with backend files if needed.
 from __future__ import annotations
 
 import json
+import os
 import shutil
 from pathlib import Path
 
@@ -184,7 +185,14 @@ class BackendRepository:
 
 
 def get_backend_repository(
-    repository: Path = Path.home() / ".mlia",
+    repository: Path | None = None,
 ) -> BackendRepository:
     """Return backend repository."""
-    return BackendRepository(repository)
+    repo_path = repository
+    if repo_path is None:
+        venv_path = os.environ.get("VIRTUAL_ENV")
+        if venv_path:
+            repo_path = Path(venv_path).resolve().joinpath(".mlia")
+        else:
+            repo_path = Path.home() / ".mlia"
+    return BackendRepository(repo_path)

--- a/tests/test_backend_install.py
+++ b/tests/test_backend_install.py
@@ -31,6 +31,7 @@ from mlia.utils.download import DownloadConfig
 def mock_backend_repo(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
     """Mock backend repository."""
     mock = MagicMock(spec=BackendRepository)
+    mock.repository = MagicMock()
     monkeypatch.setattr("mlia.backend.install.get_backend_repository", lambda: mock)
 
     return mock

--- a/tests/test_backend_repo.py
+++ b/tests/test_backend_repo.py
@@ -12,7 +12,9 @@ from mlia.backend.repo import BackendRepository
 from mlia.backend.repo import get_backend_repository
 
 
-def test_get_backend_repository(tmp_path: Path) -> None:
+def test_get_backend_repository(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Test function get_backend_repository."""
     repo_path = tmp_path / "repo"
     repo = get_backend_repository(repo_path)
@@ -26,6 +28,10 @@ def test_get_backend_repository(tmp_path: Path) -> None:
     config_file = repo_path / "mlia_config.json"
     assert config_file.is_file()
     assert json.loads(config_file.read_text()) == {"backends": []}
+
+    monkeypatch.setenv("VIRTUAL_ENV", "")
+    repo = get_backend_repository()
+    assert repo.repository == Path.home() / ".mlia"
 
 
 def test_backend_repository_wrong_directory(tmp_path: Path) -> None:


### PR DESCRIPTION
* If MLIA is installed in a venv, backend repo will create the .mlia directory inside the venv directory. Otherwise, it will fall back to ~/.mlia

Resolves MLIA-1493


Change-Id: I11bfd9e690ebf52c8365d50795bd43b26b2063eb Reviewed-on: https://eu-gerrit-2.euhpc.arm.com/c/ml/ecosystem/mlia/+/1143147
Tested-by: mlecosys <mlecosys@arm.com>
Reviewed-by: Mike Kelly <mike.kelly@arm.com>
IP-review: Mike Kelly <mike.kelly@arm.com>
(cherry picked from commit 32892c2f6e314f20eb8e2b84b3a7da1eaefbd529) Reviewed-on: https://eu-gerrit-2.euhpc.arm.com/c/ml/ecosystem/mlia/+/1151302
Tested-by: expkit <svc_expkit@arm.com>
Reviewed-by: Isabella Gottardi <isabella.gottardi@arm.com>
IP-review: Isabella Gottardi <isabella.gottardi@arm.com>