### PR TITLE
test: Improve code coverage of mlia

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,5 +47,11 @@ if __name__ == "__main__":
     from setuptools_scm import get_version  # pylint: disable=import-error
 
     tag = get_version()
+
     long_description = replace_markdown_relative_paths(Path.cwd(), "README.md", tag)
-    setup(long_description=long_description)
+
+    # Add custom suffix to version if specified
+    custom_tag_suffix = os.getenv("MLIA_CUSTOM_TAG_SUFFIX")
+    if custom_tag_suffix:
+        tag = f"{tag}.{custom_tag_suffix}"
+    setup(long_description=long_description, version=tag)

--- a/src/mlia/backend/manager.py
+++ b/src/mlia/backend/manager.py
@@ -122,6 +122,12 @@ class InstallationFiltersMixin:
         """Return list of the backends that could be installed."""
         return self.filter_by(ReadyForInstallationFilter())
 
+    def supports_installation_type(
+        self, installation_type: InstallationType
+    ) -> list[Installation]:
+        """Return list of the backends that support the installation type."""
+        return self.filter_by(SupportsInstallTypeFilter(installation_type))
+
 
 class DefaultInstallationManager(InstallationManager, InstallationFiltersMixin):
     """Interactive installation manager."""

--- a/src/mlia/nn/tensorflow/optimizations/pruning.py
+++ b/src/mlia/nn/tensorflow/optimizations/pruning.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright 2022-2024, Arm Limited and/or its affiliates.
+# SPDX-FileCopyrightText: Copyright 2022-2025, Arm Limited and/or its affiliates.
 # SPDX-License-Identifier: Apache-2.0
 """
 Contains class Pruner to prune a model to a specified sparsity.
@@ -77,9 +77,9 @@ class PrunableLayerPolicy(tfmot.sparsity.keras.PruningPolicy):
         # Check whether the model is a Keras model.
         if not isinstance(model, keras.Model):
             raise ValueError(
-                "Models that are not part of the \
-                            keras.Model base class \
-                            are not supported currently."
+                "Models that are not part of the "
+                + "keras.Model base class "
+                + "are not supported currently."
             )
 
         if not model.built:

--- a/tests/test_nn_tensorflow_config.py
+++ b/tests/test_nn_tensorflow_config.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 from typing import Generator
 from typing import Union
+from unittest.mock import MagicMock
 from unittest.mock import Mock
 
 import numpy as np
@@ -69,6 +70,22 @@ def test_invalid_tflite_model(tmp_path: Path) -> None:
 
     with pytest.raises(RuntimeError):
         TFLiteModel(model_path=model_path)
+
+
+def test_tflite_model_runtime_error(
+    test_tflite_model: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """
+    Test the throwing of a runtime error during the
+    self.interpreter.allocate_tensors call in TFLiteModel.__init__
+    """
+    monkeypatch.setattr(
+        "tensorflow.lite.Interpreter.allocate_tensors",
+        MagicMock(side_effect=RuntimeError),
+    )
+
+    with pytest.raises(RuntimeError):
+        TFLiteModel(model_path=test_tflite_model)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_utils_download.py
+++ b/tests/test_utils_download.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright 2023, Arm Limited and/or its affiliates.
+# SPDX-FileCopyrightText: Copyright 2023, 2025, Arm Limited and/or its affiliates.
 # SPDX-License-Identifier: Apache-2.0
 """Tests for download functionality."""
 from __future__ import annotations
@@ -122,11 +122,11 @@ def test_download_artifact_download_to(
 
     with expected_error:
         cfg = DownloadConfig(
-            "some_url",
+            "some.com/made/up/url/artifact_filename",
             sha256_hash,
         )
 
-        dest = tmp_path / "artifact_filename"
+        dest = tmp_path / cfg.filename
         download(dest, cfg)
         assert isinstance(dest, Path)
         assert dest.name == "artifact_filename"

--- a/tests/test_utils_misc.py
+++ b/tests/test_utils_misc.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright 2022-2023, Arm Limited and/or its affiliates.
+# SPDX-FileCopyrightText: Copyright 2022-2023, 2025, Arm Limited and/or its affiliates.
 # SPDX-License-Identifier: Apache-2.0
 """Tests for misc util functions."""
 from unittest.mock import MagicMock
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from mlia.utils.misc import get_pkg_version
+from mlia.utils.misc import MetadataError
 from mlia.utils.misc import yes
 
 
@@ -26,8 +27,18 @@ def test_yes(
     assert yes("some_prompt") == expected_result
 
 
-@pytest.mark.parametrize("response", ["some version", FileNotFoundError()])
-def test_get_pkg_version(monkeypatch: pytest.MonkeyPatch, response: str) -> None:
-    """Test get_tosa_version."""
+def test_get_pkg_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test get_pkg_version."""
+    response = "some version"
     monkeypatch.setattr("importlib.metadata.version", MagicMock(return_value=response))
     assert get_pkg_version("any name") == response
+
+
+def test_get_pkg_version_metadata_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test get_pkg_version throwa MetdataError error."""
+    exc_file_not_found = FileNotFoundError()
+    monkeypatch.setattr(
+        "importlib.metadata.version", MagicMock(side_effect=exc_file_not_found)
+    )
+    with pytest.raises(MetadataError):
+        get_pkg_version("any name")

--- a/tests/test_utils_proc.py
+++ b/tests/test_utils_proc.py
@@ -1,7 +1,10 @@
-# SPDX-FileCopyrightText: Copyright 2023, Arm Limited and/or its affiliates.
+# SPDX-FileCopyrightText: Copyright 2023, 2025, Arm Limited and/or its affiliates.
 # SPDX-License-Identifier: Apache-2.0
 """Tests for process management functions."""
+from subprocess import CalledProcessError  # nosec
 from unittest.mock import MagicMock
+
+import pytest
 
 from mlia.utils.proc import Command
 from mlia.utils.proc import process_command_output
@@ -15,3 +18,13 @@ def test_process_command_output() -> None:
     process_command_output(command, [output_consumer])
 
     output_consumer.assert_called_once_with("sample message")
+
+
+def test_process_command_output_subprocess_error() -> None:
+    """Test function process_command_output."""
+
+    command = Command(["find", "-h"])
+
+    output_consumer = MagicMock()
+    with pytest.raises(CalledProcessError):
+        process_command_output(command, [output_consumer])

--- a/tox.ini
+++ b/tox.ini
@@ -70,6 +70,8 @@ commands =
 description = Build a wheel file (platform name as optional argument [manylinux2014_aarch64, manylinux2014_x86_64]).
 deps =
     build~=1.2.1
+passenv =
+    MLIA_CUSTOM_TAG_SUFFIX
 commands =
     python -m build --wheel --config-setting=--build-option=--plat-name={posargs:manylinux2014_x86_64}
 


### PR DESCRIPTION
Improve the code coverage of:
* mlia/backend/manager.py
* mlia/nn/tensorflow
* mlia/target/registry.py
* mlia/utils

Other than top level code handling imports and entry points code coverage is at 100%.
Add a feature to use a custom tag suffix to the versioning if desired.