### PR TITLE
test: Coverage for mlia/target/tosa

### DIFF
--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright 2025, Arm Limited and/or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the various event handlers."""
+from pathlib import Path
+
+import pytest
+
+from mlia.backend.tosa_checker.compat import TOSACompatibilityInfo
+from mlia.core.context import ExecutionContext
+from mlia.core.events import CollectedDataEvent
+from mlia.core.events import ExecutionStartedEvent
+from mlia.core.handlers import WorkflowEventsHandler
+from mlia.nn.tensorflow.tflite_compat import TFLiteCompatibilityInfo
+from mlia.nn.tensorflow.tflite_compat import TFLiteCompatibilityStatus
+from mlia.target.tosa.config import TOSAConfiguration
+from mlia.target.tosa.events import TOSAAdvisorStartedEvent
+from mlia.target.tosa.handlers import TOSAEventHandler
+
+
+@pytest.mark.parametrize("handler", [(TOSAEventHandler())])
+@pytest.mark.parametrize(
+    "event",
+    [
+        CollectedDataEvent(TOSACompatibilityInfo(tosa_compatible=True, operators=[])),
+        CollectedDataEvent(
+            TFLiteCompatibilityInfo(
+                status=TFLiteCompatibilityStatus.TFLITE_CONVERSION_ERROR
+            )
+        ),
+    ],
+)
+def test_data_collection_event(
+    handler: WorkflowEventsHandler, event: CollectedDataEvent
+) -> None:
+    """Coverage for the on_collected_data function."""
+    handler.set_context(ExecutionContext())
+    handler.on_execution_started(ExecutionStartedEvent())
+    handler.on_collected_data(event)
+
+
+def test_tosa_advisor_started(test_tflite_model: Path) -> None:
+    """Coverage for the on_tosa_advisor_started function."""
+    advisor_event = TOSAAdvisorStartedEvent(
+        model=test_tflite_model,
+        target=TOSAConfiguration(target="tosa"),
+        tosa_metadata=None,
+    )
+    handler = TOSAEventHandler()
+    handler.set_context(ExecutionContext())
+    handler.on_execution_started(ExecutionStartedEvent())
+    with pytest.raises(RuntimeError):
+        handler.on_tosa_advisor_started(advisor_event)

--- a/tests/test_target_registry.py
+++ b/tests/test_target_registry.py
@@ -213,7 +213,7 @@ def test_optimization_profile_non_valid_file(
                     default_backends=["vela"],
                     advisor_factory_func=None,
                     target_profile_cls=None,
-                )
+                ),
             ],
             [
                 (

--- a/tests/test_target_tosa_advice_generation.py
+++ b/tests/test_target_tosa_advice_generation.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright 2022-2023, Arm Limited and/or its affiliates.
+# SPDX-FileCopyrightText: Copyright 2022-2023, 2025 Arm Limited and/or its affiliates.
 # SPDX-License-Identifier: Apache-2.0
 """Tests for advice generation."""
 from __future__ import annotations
@@ -9,6 +9,8 @@ from mlia.core.advice_generation import Advice
 from mlia.core.common import AdviceCategory
 from mlia.core.common import DataItem
 from mlia.core.context import ExecutionContext
+from mlia.target.common.reporters import ModelIsNotTFLiteCompatible
+from mlia.target.common.reporters import TFLiteCompatibilityCheckFailed
 from mlia.target.tosa.advice_generation import TOSAAdviceProducer
 from mlia.target.tosa.data_analysis import ModelIsNotTOSACompatible
 from mlia.target.tosa.data_analysis import ModelIsTOSACompatible
@@ -33,6 +35,30 @@ from mlia.target.tosa.data_analysis import ModelIsTOSACompatible
             ModelIsTOSACompatible(),
             {AdviceCategory.COMPATIBILITY},
             [Advice(["Model is fully TOSA compatible."])],
+        ],
+        [
+            ModelIsNotTFLiteCompatible(),
+            {AdviceCategory.COMPATIBILITY},
+            [
+                Advice(
+                    [
+                        "Model could not be converted into TensorFlow Lite format.",
+                        "Please refer to the table for more details.",
+                    ]
+                )
+            ],
+        ],
+        [
+            TFLiteCompatibilityCheckFailed(),
+            {AdviceCategory.COMPATIBILITY},
+            [
+                Advice(
+                    [
+                        "Model could not be converted into TensorFlow Lite format.",
+                        "Please refer to the table for more details.",
+                    ]
+                )
+            ],
         ],
     ],
 )

--- a/tests/test_target_tosa_advisor.py
+++ b/tests/test_target_tosa_advisor.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright 2022-2024, Arm Limited and/or its affiliates.
+# SPDX-FileCopyrightText: Copyright 2022-2025, Arm Limited and/or its affiliates.
 # SPDX-License-Identifier: Apache-2.0
 """Tests for TOSA advisor."""
 from pathlib import Path
@@ -56,6 +56,7 @@ def test_configure_and_get_tosa_advisor(
             AdviceCategory.PERFORMANCE,
             "Performance estimation is currently not supported for TOSA.",
         ],
+        [AdviceCategory.OPTIMIZATION, ""],
     ],
 )
 def test_unsupported_advice_categories(

--- a/tests/test_target_tosa_data_collection.py
+++ b/tests/test_target_tosa_data_collection.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright 2022-2023, Arm Limited and/or its affiliates.
+# SPDX-FileCopyrightText: Copyright 2022-2023, 2025 Arm Limited and/or its affiliates.
 # SPDX-License-Identifier: Apache-2.0
 """Tests for TOSA data collection module."""
 from pathlib import Path
@@ -8,6 +8,7 @@ import pytest
 
 from mlia.backend.tosa_checker.compat import TOSACompatibilityInfo
 from mlia.core.context import ExecutionContext
+from mlia.nn.tensorflow.tflite_compat import TFLiteCompatibilityInfo
 from mlia.target.tosa.data_collection import TOSAOperatorCompatibility
 
 
@@ -26,3 +27,15 @@ def test_tosa_data_collection(
     data_item = collector.collect_data()
 
     assert isinstance(data_item, TOSACompatibilityInfo)
+
+
+def test_non_tosa_data_collection(tmpdir: str) -> None:
+    """Test TOSA data collection on non tosa compatible model."""
+    tmpdir += "/" + TOSAOperatorCompatibility.name()  # For coverage
+    context = ExecutionContext(output_dir=tmpdir)
+    collector = TOSAOperatorCompatibility(Path("test.vgf"))
+    collector.set_context(context)
+
+    data_item = collector.collect_data()
+
+    assert isinstance(data_item, TFLiteCompatibilityInfo)

--- a/tests/test_target_tosa_operators.py
+++ b/tests/test_target_tosa_operators.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright 2025, Arm Limited and/or its affiliates.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for tosa-checker operators."""
+import pytest
+
+from mlia.target.tosa.operators import report
+
+
+def test_tosa_operators_report() -> None:
+    """Test operators report function."""
+    with pytest.raises(
+        NotImplementedError,
+        match="Generating a supported operators report is not "
+        "currently supported with TOSA target profile.",
+    ):
+        report()

--- a/tests/test_target_tosa_reporters.py
+++ b/tests/test_target_tosa_reporters.py
@@ -1,15 +1,29 @@
-# SPDX-FileCopyrightText: Copyright 2023, Arm Limited and/or its affiliates.
+# SPDX-FileCopyrightText: Copyright 2023, 2025 Arm Limited and/or its affiliates.
 # SPDX-License-Identifier: Apache-2.0
 """Tests for tosa-checker reporters."""
+import inspect
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 
+from mlia.backend.tosa_checker.compat import Operator
+from mlia.backend.tosa_checker.compat import TOSACompatibilityInfo
+from mlia.core.advice_generation import Advice
+from mlia.core.reporting import CompoundReport
+from mlia.core.reporting import NestedReport
 from mlia.core.reporting import Report
+from mlia.core.reporting import Table
+from mlia.nn.tensorflow.tflite_compat import TFLiteCompatibilityInfo
+from mlia.nn.tensorflow.tflite_compat import TFLiteCompatibilityStatus
 from mlia.target.tosa.config import TOSAConfiguration
 from mlia.target.tosa.reporters import MetadataDisplay
 from mlia.target.tosa.reporters import report_target
+from mlia.target.tosa.reporters import report_tosa_compatibility
+from mlia.target.tosa.reporters import report_tosa_errors
+from mlia.target.tosa.reporters import report_tosa_exception
+from mlia.target.tosa.reporters import report_tosa_operators
 from mlia.target.tosa.reporters import tosa_formatters
 
 
@@ -19,8 +33,32 @@ def test_tosa_report_target() -> None:
     assert report.to_plain_text()
 
 
+@pytest.mark.parametrize(
+    "display_data, check_pkg_version",
+    [
+        ([Advice(messages=[])], False),
+        (MetadataDisplay, True),
+        (TOSAConfiguration(target="tosa"), False),
+        (
+            [
+                Operator(
+                    name="Alpha", location="sample/location/A", is_tosa_compatible=False
+                ),
+                Operator(
+                    name="Beta", location="sample/location/B", is_tosa_compatible=False
+                ),
+            ],
+            None,
+        ),
+        (TOSACompatibilityInfo(tosa_compatible=True, operators=[]), False),
+        (TFLiteCompatibilityInfo(status=TFLiteCompatibilityStatus.COMPATIBLE), False),
+    ],
+)
 def test_tosa_formatters(
-    monkeypatch: pytest.MonkeyPatch, test_tflite_model: Path
+    display_data: Any,
+    check_pkg_version: bool,
+    monkeypatch: pytest.MonkeyPatch,
+    test_tflite_model: Path,
 ) -> None:
     """Test function tosa_formatters() with valid input."""
     mock_version = MagicMock()
@@ -29,12 +67,17 @@ def test_tosa_formatters(
         MagicMock(return_value=mock_version),
     )
 
-    display_data = MetadataDisplay(test_tflite_model)
-    formatter = tosa_formatters(MetadataDisplay(test_tflite_model))
+    if inspect.isclass(display_data):
+        display_data = display_data(test_tflite_model)
+
+    formatter = tosa_formatters(display_data)
     report = formatter(display_data)
-    assert (
-        display_data.data_dict["tosa-checker"]["tosa_checker_version"] == mock_version
-    )
+    if check_pkg_version:
+        assert (
+            display_data.data_dict["tosa-checker"]["tosa_checker_version"]
+            == mock_version
+        )
+
     assert isinstance(report, Report)
 
 
@@ -45,3 +88,24 @@ def test_tosa_formatters_invalid_data() -> None:
         match=r"^Unable to find appropriate formatter for .*",
     ):
         tosa_formatters(12)
+
+
+def test_report_tosa_operators() -> None:
+    """Test report_tosa_operators function."""
+    assert isinstance(report_tosa_operators([]), Table)
+
+
+def test_report_tosa_exception() -> None:
+    """Test report_tosa_exception function."""
+    assert isinstance(report_tosa_exception(None), NestedReport)
+
+
+def test_report_tosa_errors() -> None:
+    """Test report_tosa_errors function."""
+    assert isinstance(report_tosa_errors(err=None), NestedReport)
+
+
+def test_report_tosa_compatibility() -> None:
+    """Test report_tosa_compatibility function."""
+    compat_info = TOSACompatibilityInfo(tosa_compatible=True, operators=[])
+    assert isinstance(report_tosa_compatibility(compat_info), CompoundReport)


### PR DESCRIPTION
Resolves: MLIA-1435
Change-Id: I386ebd0a2a797b0b0f0771d001528f4f784dda81
Reviewed-on: https://eu-gerrit-2.euhpc.arm.com/c/ml/ecosystem/mlia/+/1152453
Tested-by: expkit <svc_expkit@arm.com>
Reviewed-by: Maksims Svecovs <maksims.svecovs@arm.com>
IP-review: Maksims Svecovs <maksims.svecovs@arm.com>