### PR TITLE
feat: Update requirements for python 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ typical setup requires:
 
 * Ubuntu® 22.04.5 LTS (other OSs may work, the ML Inference Advisor has been
   tested on this one specifically)
-* Python® >= 3.9
-* libpython3.9-dev (part of python3.9-dev)
+* Python® >= 3.10
+* libpython3.10-dev (part of python3.10-dev)
 
 ## Installation
 
@@ -516,7 +516,7 @@ the following table shows some compatibility information:
 | Corstone-300                      | x86_64 and  AArch64    | Not compatible | Python>=3.8      |
 | Corstone-310                      | x86_64 and  AArch64    | Not compatible | Python>=3.8      |
 | Corstone-320                      | x86_64 and  AArch64    | Not compatible | Python>=3.8      |
-| TOSA checker                      | x86_64 (manylinux2014) | Not compatible | 3.7<=Python<=3.9 |
+| TOSA checker                      | x86_64 (manylinux2014) | Not compatible | Python>=3.8      |
 | Vela                              | x86_64 and  AArch64    | Windows 10     | Python~=3.7      |
 
 ### Arm NN TensorFlow Lite Delegate

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -16,6 +16,13 @@ scheme.
   of Arm® Limited (or its subsidiaries) in the U.S. and/or elsewhere.
 * TensorFlow™ is a trademark of Google® LLC.
 
+## Next
+
+### Internal changes
+
+* Minimum required Python version bumped to 3.10
+* Minimum required TensorFlow version bumped to 2.20
+
 ## 0.9.2 (2025-10-31)
 
 ### Feature changes

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,12 +31,14 @@ packages = find_namespace:
 #   https://github.com/h5py/h5py/issues/2408
 # Idea is to unpin these when it's resolved.
 install_requires =
-    tensorflow==2.15.1
-    h5py==3.10.0
-    tensorflow-model-optimization~=0.7.5
+    numpy>=2.0.0
+    tensorflow==2.20.0
+    tf-keras==2.20.1
+    h5py>=3.12.1
     requests~=2.32.3
     rich~=13.7.1
     tomli>=2.0.1 ; python_version<"3.11"
+    tf-model-optimization-nightly @ git+https://github.com/tensorflow/model-optimization.git@e2d531b
 
 [options.packages.find]
 where = src

--- a/setup.py
+++ b/setup.py
@@ -54,4 +54,8 @@ if __name__ == "__main__":
     custom_tag_suffix = os.getenv("MLIA_CUSTOM_TAG_SUFFIX")
     if custom_tag_suffix:
         tag = f"{tag}.{custom_tag_suffix}"
-    setup(long_description=long_description, version=tag)
+
+    setup(
+        long_description=long_description,
+        version=tag,
+    )

--- a/src/mlia/nn/rewrite/core/rewrite.py
+++ b/src/mlia/nn/rewrite/core/rewrite.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright 2023-2024, Arm Limited and/or its affiliates.
+# SPDX-FileCopyrightText: Copyright 2023-2025, Arm Limited and/or its affiliates.
 # SPDX-License-Identifier: Apache-2.0
 """Contains class RewritingOptimizer to replace a subgraph/layer of a model."""
 from __future__ import annotations
@@ -18,7 +18,7 @@ from typing import Generator
 import numpy as np
 import tensorflow as tf
 import tensorflow_model_optimization as tfmot
-from keras.api._v2 import keras  # Temporary workaround for now: MLIA-1107
+import tf_keras as keras
 from tensorflow_model_optimization.python.core.sparsity.keras.pruning_utils import (  # pylint: disable=no-name-in-module
     is_pruned_m_by_n,
 )

--- a/src/mlia/nn/rewrite/core/train.py
+++ b/src/mlia/nn/rewrite/core/train.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright 2023-2024, Arm Limited and/or its affiliates.
+# SPDX-FileCopyrightText: Copyright 2023-2025, Arm Limited and/or its affiliates.
 # SPDX-License-Identifier: Apache-2.0
 """Sequential trainer."""
 # pylint: disable=too-many-arguments
@@ -23,7 +23,7 @@ from typing import Literal
 
 import numpy as np
 import tensorflow as tf
-from keras.api._v2 import keras  # Temporary workaround for now: MLIA-1107
+import tf_keras as keras
 from numpy.random import Generator
 
 from mlia.nn.rewrite.core.extract import extract

--- a/src/mlia/nn/rewrite/library/clustering.py
+++ b/src/mlia/nn/rewrite/library/clustering.py
@@ -1,10 +1,10 @@
-# SPDX-FileCopyrightText: Copyright 2024, Arm Limited and/or its affiliates.
+# SPDX-FileCopyrightText: Copyright 2024-2025, Arm Limited and/or its affiliates.
 # SPDX-License-Identifier: Apache-2.0
 """Rewrite functions used to return layers ready for clustering."""
 from typing import Any
 
 import tensorflow_model_optimization as tfmot
-from keras.api._v2 import keras  # Temporary workaround for now: MLIA-1107
+import tf_keras as keras
 
 from mlia.nn.rewrite.library.helper_functions import compute_conv2d_parameters
 from mlia.nn.rewrite.library.helper_functions import get_activation_function

--- a/src/mlia/nn/rewrite/library/helper_functions.py
+++ b/src/mlia/nn/rewrite/library/helper_functions.py
@@ -1,11 +1,11 @@
-# SPDX-FileCopyrightText: Copyright 2024, Arm Limited and/or its affiliates.
+# SPDX-FileCopyrightText: Copyright 2024-2025, Arm Limited and/or its affiliates.
 # SPDX-License-Identifier: Apache-2.0
 """Helper functions for the rewrite library."""
 import math
 from typing import Any
 
 import numpy as np
-from keras.api._v2 import keras  # Temporary workaround for now: MLIA-1107
+import tf_keras as keras
 
 ACTIVATION_FUNCTION_PRESETS = {
     "relu": {"layer_func": keras.layers.ReLU, "extra_args": {}},

--- a/src/mlia/nn/rewrite/library/layers.py
+++ b/src/mlia/nn/rewrite/library/layers.py
@@ -1,9 +1,9 @@
-# SPDX-FileCopyrightText: Copyright 2023-2024, Arm Limited and/or its affiliates.
+# SPDX-FileCopyrightText: Copyright 2023-2025, Arm Limited and/or its affiliates.
 # SPDX-License-Identifier: Apache-2.0
 """Rewrite function used to return regular layers."""
 from typing import Any
 
-from keras.api._v2 import keras  # Temporary workaround for now: MLIA-1107
+import tf_keras as keras
 
 from mlia.nn.rewrite.library.helper_functions import compute_conv2d_parameters
 from mlia.nn.rewrite.library.helper_functions import get_activation_function

--- a/src/mlia/nn/rewrite/library/sparsity.py
+++ b/src/mlia/nn/rewrite/library/sparsity.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright 2024, Arm Limited and/or its affiliates.
+# SPDX-FileCopyrightText: Copyright 2024-2025, Arm Limited and/or its affiliates.
 # SPDX-License-Identifier: Apache-2.0
 """Rewrite functions used to return layers ready for sparse pruning."""
 from __future__ import annotations
@@ -6,7 +6,7 @@ from __future__ import annotations
 from typing import Any
 
 import tensorflow_model_optimization as tfmot
-from keras.api._v2 import keras  # Temporary workaround for now: MLIA-1107
+import tf_keras as keras
 
 from mlia.nn.rewrite.library.helper_functions import compute_conv2d_parameters
 from mlia.nn.rewrite.library.helper_functions import get_activation_function

--- a/src/mlia/nn/select.py
+++ b/src/mlia/nn/select.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright 2022-2024, Arm Limited and/or its affiliates.
+# SPDX-FileCopyrightText: Copyright 2022-2025, Arm Limited and/or its affiliates.
 # SPDX-License-Identifier: Apache-2.0
 """Module for optimization selection."""
 from __future__ import annotations
@@ -10,7 +10,7 @@ from typing import cast
 from typing import List
 from typing import NamedTuple
 
-from keras.api._v2 import keras  # Temporary workaround for now: MLIA-1107
+import tf_keras as keras
 
 from mlia.core.errors import ConfigurationError
 from mlia.nn.common import Optimizer

--- a/src/mlia/nn/tensorflow/config.py
+++ b/src/mlia/nn/tensorflow/config.py
@@ -15,7 +15,7 @@ from typing import List
 
 import numpy as np
 import tensorflow as tf
-from keras.api._v2 import keras  # Temporary workaround for now: MLIA-1107
+import tf_keras as keras
 
 from mlia.core.context import Context
 from mlia.nn.tensorflow.optimizations.quantization import dequantize

--- a/src/mlia/nn/tensorflow/optimizations/clustering.py
+++ b/src/mlia/nn/tensorflow/optimizations/clustering.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright 2022-2024, Arm Limited and/or its affiliates.
+# SPDX-FileCopyrightText: Copyright 2022-2025, Arm Limited and/or its affiliates.
 # SPDX-License-Identifier: Apache-2.0
 """
 Contains class Clusterer that clusters unique weights per layer to a specified number.
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import tensorflow_model_optimization as tfmot
-from keras.api._v2 import keras  # Temporary workaround for now: MLIA-1107
+import tf_keras as keras
 from tensorflow_model_optimization.python.core.clustering.keras.experimental import (  # pylint: disable=no-name-in-module
     cluster as experimental_cluster,
 )
@@ -61,10 +61,10 @@ class Clusterer(Optimizer):
         return str(self.optimizer_configuration)
 
     def _setup_clustering_params(self) -> dict[str, Any]:
-        CentroidInitialization = tfmot.clustering.keras.CentroidInitialization
+        centroid_initialization = tfmot.clustering.keras.CentroidInitialization
         return {
             "number_of_clusters": self.optimizer_configuration.optimization_target,
-            "cluster_centroids_init": CentroidInitialization.LINEAR,
+            "cluster_centroids_init": centroid_initialization.LINEAR,
             "preserve_sparsity": True,
         }
 

--- a/src/mlia/nn/tensorflow/optimizations/pruning.py
+++ b/src/mlia/nn/tensorflow/optimizations/pruning.py
@@ -16,7 +16,7 @@ from typing import Any
 
 import numpy as np
 import tensorflow_model_optimization as tfmot
-from keras.api._v2 import keras  # Temporary workaround for now: MLIA-1107
+import tf_keras as keras
 from tensorflow_model_optimization.python.core.sparsity.keras import (  # pylint: disable=no-name-in-module
     prune_registry,
 )

--- a/src/mlia/nn/tensorflow/optimizations/quantization.py
+++ b/src/mlia/nn/tensorflow/optimizations/quantization.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright 2023, Arm Limited and/or its affiliates.
+# SPDX-FileCopyrightText: Copyright 2023,2025, Arm Limited and/or its affiliates.
 # SPDX-License-Identifier: Apache-2.0
 """Contains functionality for quantization and de-quantization."""
 from __future__ import annotations
@@ -30,7 +30,7 @@ class QuantizationParameters:
 
 def is_quantized(quant_params: QuantizationParameters) -> bool:
     """Check if the quantization parameters describe a quantized tensor."""
-    return quant_params.scales.size > 0
+    return bool(quant_params.scales.size > 0)
 
 
 def dequantize(
@@ -49,7 +49,7 @@ def dequantize(
         "but it must be int."
     )
 
-    dequantized_tensor = np.subtract(
+    dequantized_tensor: np.ndarray = np.subtract(
         quantized_tensor, quant_params.zero_points, dtype=np.float32
     )
     dequantized_tensor = np.multiply(

--- a/src/mlia/nn/tensorflow/tflite_convert.py
+++ b/src/mlia/nn/tensorflow/tflite_convert.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright 2022-2024, Arm Limited and/or its affiliates.
+# SPDX-FileCopyrightText: Copyright 2022-2025, Arm Limited and/or its affiliates.
 # SPDX-License-Identifier: Apache-2.0
 """Support module to call TFLiteConverter."""
 from __future__ import annotations
@@ -14,7 +14,7 @@ from typing import Iterable
 
 import numpy as np
 import tensorflow as tf
-from keras.api._v2 import keras  # Temporary workaround for now: MLIA-1107
+import tf_keras as keras
 
 from mlia.nn.tensorflow.utils import get_tf_tensor_shape
 from mlia.nn.tensorflow.utils import is_keras_model

--- a/src/mlia/nn/tensorflow/tflite_metrics.py
+++ b/src/mlia/nn/tensorflow/tflite_metrics.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright 2022, Arm Limited and/or its affiliates.
+# SPDX-FileCopyrightText: Copyright 2022,2025, Arm Limited and/or its affiliates.
 # SPDX-License-Identifier: Apache-2.0
 """
 Contains class TFLiteMetrics to calculate metrics from a TensorFlow Lite file.
@@ -112,7 +112,11 @@ class TFLiteMetrics:
     * File compression via gzip
     """
 
-    def __init__(self, tflite_file: str, ignore_list: list[str] | None = None) -> None:
+    def __init__(
+        self,
+        tflite_file: str,
+        ignore_list: list[str] | None = None,
+    ) -> None:
         """Load the TensorFlow Lite file and filter layers."""
         self.tflite_file = tflite_file
         if ignore_list is None:

--- a/src/mlia/nn/tensorflow/utils.py
+++ b/src/mlia/nn/tensorflow/utils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright 2022-2024, Arm Limited and/or its affiliates.
+# SPDX-FileCopyrightText: Copyright 2022-2025, Arm Limited and/or its affiliates.
 # SPDX-FileCopyrightText: Copyright The TensorFlow Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 """Collection of useful functions for optimizations."""
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any
 
 import tensorflow as tf
-from keras.api._v2 import keras  # Temporary workaround for now: MLIA-1107
+import tf_keras as keras
 
 
 def get_tf_tensor_shape(model: str) -> list:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,23 +1,23 @@
 # SPDX-FileCopyrightText: Copyright 2022-2025, Arm Limited and/or its affiliates.
 # SPDX-License-Identifier: Apache-2.0
 """Pytest conf module."""
+# mypy: disable-error-code=misc
 import shutil
 from pathlib import Path
 from typing import Callable
 from typing import Generator
 from unittest.mock import MagicMock
 
-import _pytest
 import numpy as np
 import pytest
 import tensorflow as tf
-from keras.api._v2 import keras  # Temporary workaround for now: MLIA-1107
+import tf_keras as keras
 
-from mlia.core.context import ExecutionContext
-from mlia.nn.rewrite.core.utils.numpy_tfrecord import NumpyTFWriter
-from mlia.nn.tensorflow.tflite_convert import convert_to_tflite
-from mlia.nn.tensorflow.utils import save_keras_model
-from tests.utils.rewrite import MockTrainingParameters
+from mlia.core.context import ExecutionContext  # noqa: E402
+from mlia.nn.rewrite.core.utils.numpy_tfrecord import NumpyTFWriter  # noqa: E402
+from mlia.nn.tensorflow.tflite_convert import convert_to_tflite  # noqa: E402
+from mlia.nn.tensorflow.utils import save_keras_model  # noqa: E402
+from tests.utils.rewrite import MockTrainingParameters  # noqa: E402
 
 
 @pytest.fixture(scope="session", name="test_resources_path")
@@ -285,7 +285,7 @@ def fixture_test_tfrecord_fp32(
 
 @pytest.fixture(scope="function", autouse=True)
 def set_training_steps(
-    request: _pytest.fixtures.SubRequest,
+    request: pytest.FixtureRequest,
 ) -> Generator[None, None, None]:
     """Speed up tests by using MockTrainingParameters."""
     if "skip_set_training_steps" not in request.keywords:

--- a/tests/test_nn_rewrite_core_rewrite.py
+++ b/tests/test_nn_rewrite_core_rewrite.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock
 import numpy as np
 import pytest
 import tensorflow_model_optimization as tfmot
-from keras.api._v2 import keras  # Temporary workaround for now: MLIA-1107
+import tf_keras as keras
 from tensorflow_model_optimization.python.core.clustering.keras.cluster_wrapper import (  # pylint: disable=no-name-in-module
     ClusterWeights,
 )

--- a/tests/test_nn_rewrite_core_train.py
+++ b/tests/test_nn_rewrite_core_train.py
@@ -12,7 +12,7 @@ from typing import Any
 import numpy as np
 import pytest
 import tensorflow as tf
-from keras.api._v2 import keras  # Temporary workaround for now: MLIA-1107
+import tf_keras as keras
 
 from mlia.nn.rewrite.core.rewrite import GenericRewrite
 from mlia.nn.rewrite.core.rewrite import SparsityRewrite

--- a/tests/test_nn_rewrite_library_helper_functions.py
+++ b/tests/test_nn_rewrite_library_helper_functions.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright 2024, Arm Limited and/or its affiliates.
+# SPDX-FileCopyrightText: Copyright 2024-2025, Arm Limited and/or its affiliates.
 # SPDX-License-Identifier: Apache-2.0
 """Tests for module mlia.nn.rewrite.library.helper_functions."""
 from __future__ import annotations
@@ -8,7 +8,7 @@ from typing import Any
 
 import numpy as np
 import pytest
-from keras.api._v2 import keras  # Temporary workaround for now: MLIA-1107
+import tf_keras as keras
 
 from mlia.nn.rewrite.library.helper_functions import ACTIVATION_FUNCTION_LIST
 from mlia.nn.rewrite.library.helper_functions import compute_conv2d_parameters

--- a/tests/test_nn_select.py
+++ b/tests/test_nn_select.py
@@ -10,7 +10,7 @@ from typing import cast
 
 import pytest
 import tensorflow_model_optimization as tfmot
-from keras.api._v2 import keras  # Temporary workaround for now: MLIA-1107
+import tf_keras as keras
 
 from mlia.core.errors import ConfigurationError
 from mlia.nn.rewrite.core.rewrite import RewriteConfiguration

--- a/tests/test_nn_tensorflow_optimizations_pruning.py
+++ b/tests/test_nn_tensorflow_optimizations_pruning.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from keras.api._v2 import keras  # Temporary workaround for now: MLIA-1107
-from numpy.core.numeric import isclose
+import tf_keras as keras
+from numpy import isclose
 
 from mlia.nn.tensorflow.optimizations.pruning import PrunableLayerPolicy
 from mlia.nn.tensorflow.optimizations.pruning import Pruner
@@ -25,12 +25,12 @@ def _test_sparsity(
 ) -> None:
     pruned_sparsity_dict = metrics.sparsity_per_layer()
     num_sparse_layers = 0
-    num_optimizable_layers = len(pruned_sparsity_dict)
     error_margin = 0.03
     if layers_to_prune:
         expected_num_sparse_layers = len(layers_to_prune)
     else:
-        expected_num_sparse_layers = num_optimizable_layers
+        expected_num_sparse_layers = 3
+
     for layer_name in pruned_sparsity_dict:
         if abs(pruned_sparsity_dict[layer_name] - target_sparsity) < error_margin:
             num_sparse_layers = num_sparse_layers + 1
@@ -80,7 +80,6 @@ def test_prune_simple_model_fully(
         tflite_fn="test_prune_simple_model_fully_before.tflite",
         model=base_model,
     )
-
     # Make sure sparsity is zero before pruning
     _test_check_sparsity(base_tflite_metrics)
 
@@ -114,7 +113,6 @@ def test_prune_simple_model_fully(
         tflite_fn="test_prune_simple_model_fully_after.tflite",
         model=pruned_model,
     )
-
     _test_sparsity(pruned_tflite_metrics, target_sparsity, layers_to_prune)
 
 

--- a/tests/test_nn_tensorflow_optimizations_quantization.py
+++ b/tests/test_nn_tensorflow_optimizations_quantization.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright 2023, Arm Limited and/or its affiliates.
+# SPDX-FileCopyrightText: Copyright 2023, 2025, Arm Limited and/or its affiliates.
 # SPDX-License-Identifier: Apache-2.0
 """Tests for module optimizations/quantization."""
 from __future__ import annotations
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Generator
 
 import numpy as np
-from numpy.core.numeric import isclose
+from numpy import isclose
 
 from mlia.nn.tensorflow.config import TFLiteModel
 from mlia.nn.tensorflow.optimizations.quantization import dequantize

--- a/tests/test_nn_tensorflow_tflite_convert.py
+++ b/tests/test_nn_tensorflow_tflite_convert.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright 2022-2024, Arm Limited and/or its affiliates.
+# SPDX-FileCopyrightText: Copyright 2022-2025, Arm Limited and/or its affiliates.
 # SPDX-License-Identifier: Apache-2.0
 """Test for module utils/test_utils."""
 import os
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock
 import numpy as np
 import pytest
 import tensorflow as tf
-from keras.api._v2 import keras  # Temporary workaround for now: MLIA-1107
+import tf_keras as keras
 
 from mlia.nn.tensorflow import tflite_convert
 from mlia.nn.tensorflow.tflite_convert import convert_to_tflite

--- a/tests/test_nn_tensorflow_utils.py
+++ b/tests/test_nn_tensorflow_utils.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock
 import numpy as np
 import pytest
 import tensorflow as tf
-from keras.api._v2 import keras  # Temporary workaround for now: MLIA-1107
+import tf_keras as keras
 
 from mlia.nn.tensorflow.tflite_convert import convert_to_tflite
 from mlia.nn.tensorflow.utils import check_tflite_datatypes

--- a/tests/test_target_cortex_a_operators.py
+++ b/tests/test_target_cortex_a_operators.py
@@ -1,10 +1,10 @@
-# SPDX-FileCopyrightText: Copyright 2022-2024, Arm Limited and/or its affiliates.
+# SPDX-FileCopyrightText: Copyright 2022-2025, Arm Limited and/or its affiliates.
 # SPDX-License-Identifier: Apache-2.0
 """Tests for Cortex-A operator compatibility."""
 from pathlib import Path
 
 import pytest
-from keras.api._v2 import keras  # Temporary workaround for now: MLIA-1107
+import tf_keras as keras
 
 from mlia.nn.tensorflow.tflite_convert import convert_to_tflite_bytes
 from mlia.target.cortex_a.config import CortexAConfiguration

--- a/tests/utils/common.py
+++ b/tests/utils/common.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright 2022-2024, Arm Limited and/or its affiliates.
+# SPDX-FileCopyrightText: Copyright 2022-2025, Arm Limited and/or its affiliates.
 # SPDX-License-Identifier: Apache-2.0
 """Common test utils module."""
 from __future__ import annotations
@@ -6,7 +6,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import numpy as np
-from keras.api._v2 import keras  # Temporary workaround for now: MLIA-1107
+import tf_keras as keras
 
 
 def get_dataset() -> tuple[np.ndarray, np.ndarray]:
@@ -17,7 +17,7 @@ def get_dataset() -> tuple[np.ndarray, np.ndarray]:
 
     # Use subset of 60000 examples to keep unit test speed fast.
     x_train = x_train[0:1]
-    y_train = y_train[0:1]
+    y_train = y_train[0:1]  # pylint: disable=unsubscriptable-object
 
     return x_train, y_train
 


### PR DESCRIPTION
* Build tensorflow-model-optimization dependency from the github commit https://github.com/tensorflow/model-optimization/commit/e2d531bfa2ce10916a1066c67b1438d17cc67dac
* Update numpy version to 2.0.0
* Update tensorflow version to 2.20.0
* Add tf-keras 2.20.1
* Update keras imports to use tf_keras as keras

fix: Type annotation added in
  mlia/nn/tensorflow/optimizations/quantization.py

Resolve:  MLIA-1612


Change-Id: Id76d7eeade25f24b64f3646e969ebdcaad64f445 Reviewed-on: https://eu-gerrit-2.euhpc.arm.com/c/ml/ecosystem/mlia/+/1162803
Tested-by: expkit <svc_expkit@arm.com>
Reviewed-by: Isabella Gottardi <isabella.gottardi@arm.com>
IP-review: Isabella Gottardi <isabella.gottardi@arm.com>
(cherry picked from commit 1628f03309b4c460f077e84dd11ce944bfbf951b)


Change-Id: I0e1ff16ee8ce859efc8fc38379f582fe86a378e6 Reviewed-on: https://eu-gerrit-2.euhpc.arm.com/c/ml/ecosystem/mlia/+/1158345
Reviewed-by: Isabella Gottardi <isabella.gottardi@arm.com>
(cherry picked from commit 39472d16c439621a11533879c369b0dfa81f6008)