### PR TITLE
docs: clarify bug reporting issue routing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,16 @@ for details of how to create a pull request.
 Contributions must go through code review on GitHub. Only reviewed contributions
 can go to the main branch of MLIA.
 
+### Reporting bugs
+
+Report bugs by creating GitHub issues. Use the
+[`arm/mlia` issue tracker](https://github.com/arm/mlia/issues) by default,
+especially when the ownership is unclear or the problem spans multiple MLIA
+repos.
+
+Only file an issue in a plugin repository when the bug is obviously and
+specifically confined to that plugin.
+
 ## Developer Certificate of Origin (DCO)
 
 Before the MLIA project accepts your contribution, you need to certify its

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ available in the environment.
 - [Plugin model](#plugin-model)
 - [Quick start](#quick-start)
 - [Python API](#python-api)
+- [Reporting bugs](#reporting-bugs)
 - [Development](#development)
 
 ## Inclusive language commitment
@@ -159,6 +160,15 @@ pip install mlia[torch]
 The Python API follows the same plugin-based architecture as the CLI: the core
 package provides the entry points and shared output structure, while installed
 plugins extend what targets and backends are available.
+
+## Reporting bugs
+
+Report bugs by creating a GitHub issue. Use the
+[`arm/mlia` issue tracker](https://github.com/arm/mlia/issues) by default,
+including when you are not sure which repo owns the problem.
+
+Only file an issue in a plugin repository if the bug is clearly and
+specifically isolated to that plugin.
 
 ## Development
 


### PR DESCRIPTION
- add bug reporting guidance
- default users to mlia core issues unless the bug is clearly plugin-specific