### PR TITLE
feat: improve openspec-apply-change skill score 74% → 90%

### DIFF
--- a/.codex/skills/openspec-apply-change/SKILL.md
+++ b/.codex/skills/openspec-apply-change/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openspec-apply-change
-description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+description: "Implement tasks from an OpenSpec change by reading task definitions, generating code changes, marking tasks complete, and tracking progress. Use when the user wants to start or resume implementation, work through spec tasks, check the task list, or apply the next pending change."
 license: MIT
 compatibility: Requires openspec CLI.
 metadata:
@@ -9,9 +9,9 @@ metadata:
   generatedBy: "1.2.0"
 ---
 
-Implement tasks from an OpenSpec change.
+Implement tasks from an OpenSpec change — read task definitions, generate focused code changes, update task status, and report progress.
 
-**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+**Input**: Optionally specify a change name (e.g., `apply add-auth`). If omitted, infer from conversation context. If vague or ambiguous, MUST prompt for available changes.
 
 **Steps**
 
@@ -38,23 +38,16 @@ Implement tasks from an OpenSpec change.
    openspec instructions apply --change "<name>" --json
    ```
 
-   This returns:
-   - Context file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
-   - Progress (total, complete, remaining)
-   - Task list with status
-   - Dynamic instruction based on current state
+   This returns context file paths, progress (total/complete/remaining), task list with status, and a dynamic instruction.
 
    **Handle states:**
-   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
-   - If `state: "all_done"`: congratulate, suggest archive
+   - `state: "blocked"` (missing artifacts): show message, suggest openspec-continue-change
+   - `state: "all_done"`: congratulate, suggest archive
    - Otherwise: proceed to implementation
 
 4. **Read context files**
 
-   Read the files listed in `contextFiles` from the apply instructions output.
-   The files depend on the schema being used:
-   - **spec-driven**: proposal, specs, design, tasks
-   - Other schemas: follow the contextFiles from CLI output
+   Read all files listed in `contextFiles` from the apply instructions output. File sets vary by schema (e.g., spec-driven uses proposal/specs/design/tasks).
 
 5. **Show current progress**
 
@@ -87,70 +80,15 @@ Implement tasks from an OpenSpec change.
    - If all done: suggest archive
    - If paused: explain why and wait for guidance
 
-**Output During Implementation**
-
-```
-## Implementing: <change-name> (schema: <schema-name>)
-
-Working on task 3/7: <task description>
-[...implementation happening...]
-✓ Task complete
-
-Working on task 4/7: <task description>
-[...implementation happening...]
-✓ Task complete
-```
-
-**Output On Completion**
-
-```
-## Implementation Complete
-
-**Change:** <change-name>
-**Schema:** <schema-name>
-**Progress:** 7/7 tasks complete ✓
-
-### Completed This Session
-- [x] Task 1
-- [x] Task 2
-...
-
-All tasks complete! Ready to archive this change.
-```
-
-**Output On Pause (Issue Encountered)**
-
-```
-## Implementation Paused
-
-**Change:** <change-name>
-**Schema:** <schema-name>
-**Progress:** 4/7 tasks complete
-
-### Issue Encountered
-<description of the issue>
-
-**Options:**
-1. <option 1>
-2. <option 2>
-3. Other approach
-
-What would you like to do?
-```
+**Output format**: Always show `## Implementing: <change-name> (schema: <schema-name>)` as a header, then for each task: `Working on task N/M: <description>` followed by `✓ Task complete`. On completion, show final progress (`N/N tasks complete ✓`) and suggest archiving. On pause, show the issue encountered with numbered options for the user.
 
 **Guardrails**
-- Keep going through tasks until done or blocked
-- Always read context files before starting (from the apply instructions output)
-- If task is ambiguous, pause and ask before implementing
-- If implementation reveals issues, pause and suggest artifact updates
+- Always read context files (from apply instructions output) before starting — use `contextFiles` from CLI output, don't assume file names
 - Keep code changes minimal and scoped to each task
-- Update task checkbox immediately after completing each task
-- Pause on errors, blockers, or unclear requirements - don't guess
-- Use contextFiles from CLI output, don't assume specific file names
+- Update task checkbox (`- [ ]` → `- [x]`) immediately after completing each task
+- Pause and ask before proceeding when: task is ambiguous, implementation reveals a design issue (suggest artifact updates), error or blocker encountered, or user interrupts — never guess
+- Keep going through tasks until done or blocked
 
 **Fluid Workflow Integration**
 
-This skill supports the "actions on a change" model:
-
-- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
-- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly
+This skill can be invoked anytime — before all artifacts are done (if tasks exist), after partial implementation, or interleaved with other actions. If implementation reveals design issues, suggest updating artifacts rather than blocking.

--- a/.github/skills/openspec-apply-change/SKILL.md
+++ b/.github/skills/openspec-apply-change/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openspec-apply-change
-description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+description: "Implement tasks from an OpenSpec change by reading task definitions, generating code changes, marking tasks complete, and tracking progress. Use when the user wants to start or resume implementation, work through spec tasks, check the task list, or apply the next pending change."
 license: MIT
 compatibility: Requires openspec CLI.
 metadata:
@@ -9,9 +9,9 @@ metadata:
   generatedBy: "1.2.0"
 ---
 
-Implement tasks from an OpenSpec change.
+Implement tasks from an OpenSpec change — read task definitions, generate focused code changes, update task status, and report progress.
 
-**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+**Input**: Optionally specify a change name (e.g., `apply add-auth`). If omitted, infer from conversation context. If vague or ambiguous, MUST prompt for available changes.
 
 **Steps**
 
@@ -38,23 +38,16 @@ Implement tasks from an OpenSpec change.
    openspec instructions apply --change "<name>" --json
    ```
 
-   This returns:
-   - Context file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
-   - Progress (total, complete, remaining)
-   - Task list with status
-   - Dynamic instruction based on current state
+   This returns context file paths, progress (total/complete/remaining), task list with status, and a dynamic instruction.
 
    **Handle states:**
-   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
-   - If `state: "all_done"`: congratulate, suggest archive
+   - `state: "blocked"` (missing artifacts): show message, suggest openspec-continue-change
+   - `state: "all_done"`: congratulate, suggest archive
    - Otherwise: proceed to implementation
 
 4. **Read context files**
 
-   Read the files listed in `contextFiles` from the apply instructions output.
-   The files depend on the schema being used:
-   - **spec-driven**: proposal, specs, design, tasks
-   - Other schemas: follow the contextFiles from CLI output
+   Read all files listed in `contextFiles` from the apply instructions output. File sets vary by schema (e.g., spec-driven uses proposal/specs/design/tasks).
 
 5. **Show current progress**
 
@@ -87,70 +80,15 @@ Implement tasks from an OpenSpec change.
    - If all done: suggest archive
    - If paused: explain why and wait for guidance
 
-**Output During Implementation**
-
-```
-## Implementing: <change-name> (schema: <schema-name>)
-
-Working on task 3/7: <task description>
-[...implementation happening...]
-✓ Task complete
-
-Working on task 4/7: <task description>
-[...implementation happening...]
-✓ Task complete
-```
-
-**Output On Completion**
-
-```
-## Implementation Complete
-
-**Change:** <change-name>
-**Schema:** <schema-name>
-**Progress:** 7/7 tasks complete ✓
-
-### Completed This Session
-- [x] Task 1
-- [x] Task 2
-...
-
-All tasks complete! Ready to archive this change.
-```
-
-**Output On Pause (Issue Encountered)**
-
-```
-## Implementation Paused
-
-**Change:** <change-name>
-**Schema:** <schema-name>
-**Progress:** 4/7 tasks complete
-
-### Issue Encountered
-<description of the issue>
-
-**Options:**
-1. <option 1>
-2. <option 2>
-3. Other approach
-
-What would you like to do?
-```
+**Output format**: Always show `## Implementing: <change-name> (schema: <schema-name>)` as a header, then for each task: `Working on task N/M: <description>` followed by `✓ Task complete`. On completion, show final progress (`N/N tasks complete ✓`) and suggest archiving. On pause, show the issue encountered with numbered options for the user.
 
 **Guardrails**
-- Keep going through tasks until done or blocked
-- Always read context files before starting (from the apply instructions output)
-- If task is ambiguous, pause and ask before implementing
-- If implementation reveals issues, pause and suggest artifact updates
+- Always read context files (from apply instructions output) before starting — use `contextFiles` from CLI output, don't assume file names
 - Keep code changes minimal and scoped to each task
-- Update task checkbox immediately after completing each task
-- Pause on errors, blockers, or unclear requirements - don't guess
-- Use contextFiles from CLI output, don't assume specific file names
+- Update task checkbox (`- [ ]` → `- [x]`) immediately after completing each task
+- Pause and ask before proceeding when: task is ambiguous, implementation reveals a design issue (suggest artifact updates), error or blocker encountered, or user interrupts — never guess
+- Keep going through tasks until done or blocked
 
 **Fluid Workflow Integration**
 
-This skill supports the "actions on a change" model:
-
-- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
-- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly
+This skill can be invoked anytime — before all artifacts are done (if tasks exist), after partial implementation, or interleaved with other actions. If implementation reveals design issues, suggest updating artifacts rather than blocking.


### PR DESCRIPTION
Hey @benkli01 👋

ML Inference Advisor is a cool concept, helping developers evaluate model compatibility for different inference targets before they're too deep in. The OpenSpec workflow reference in your AGENTS.md shows you're thinking about structured agent collaboration, which is great to see in a hardware-adjacent tool.

ran your skills through `tessl skill review` at work and found some targeted improvements for `openspec-apply-change`. Here's the before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| openspec-apply-change | 74% | 90% | +16% |

<details>
<summary>Changes made</summary>

**Description improvements (biggest impact - 57% → 100%):**
- Rewrote the description to list concrete actions: reading task definitions, generating code changes, marking tasks complete, tracking progress
- Added explicit "Use when..." clause with natural trigger terms: "start or resume implementation", "spec tasks", "task list", "next pending change"
- Added an inline example invocation to the input section for discoverability

**Content improvements (77% → 77%, maintained while reducing bulk):**
- Consolidated three verbose output format blocks (implementation, completion, pause) into a single concise output format paragraph - same information, ~60% fewer lines
- Merged redundant pause/blocker conditions that were duplicated between step 6 and the Guardrails section into one consolidated list
- Tightened the Fluid Workflow Integration section from a bulleted pair into a single focused paragraph
- Kept both `.github/skills/` and `.codex/skills/` copies in sync

**What stayed the same:**
- All 7 workflow steps preserved with their CLI commands and state handling logic
- Guardrail intent unchanged - just consolidated
- OpenSpec-specific terminology and domain framing preserved throughout

</details>

---

also stress-tested your `openspec-apply-change` skill against [a few real-world task evals](https://tessl.io/registry/skills/github/arm/mlia/openspec-apply-change/evals) and it held up really well on multi-schema task iteration with blocked-state recovery. Kudos for that.

quick honest disclosure. I work at https://github.com/tesslio where we build tooling around skills like these. Not a pitch, just saw room for improvement and wanted to contribute.

if you want to self-improve your skills, or define your own scenarios to pressure test, just ask your agent (Claude Code, Codex, etc.) to evaluate and optimize your skill with Tessl. Ping me [@yogesh-tessl](https://github.com/yogesh-tessl), if you hit any snags.